### PR TITLE
Revert "The IRP threads have a LOT of overhead, the object should be kep...

### DIFF
--- a/src/main/java/chdk/ptp/java/connection/PTPConnection.java
+++ b/src/main/java/chdk/ptp/java/connection/PTPConnection.java
@@ -68,8 +68,7 @@ public class PTPConnection {
             // Send init command
             long startTime = System.nanoTime();
             p.setTransaction(Seq);
-            if(write == null)
-                write = camOutpipe.createUsbIrp();
+            write = camOutpipe.createUsbIrp();
             write.setData(p.getPacket());
             write.setLength(p.getPacket().length);
             write.setOffset(0);
@@ -77,7 +76,6 @@ public class PTPConnection {
 
             camOutpipe.syncSubmit(write);
             write.waitUntilComplete(10000);
-            write.complete();
             long stopTime = System.nanoTime();
             // System.out.println("TX Delta:\t"+((stopTime -
             // startTime)/(float)10000000)+"ms");
@@ -93,8 +91,7 @@ public class PTPConnection {
 
         if (camInpipe == null)
             throw new CameraConnectionException("My pipe is null.!");
-        if(read == null)
-            read = camInpipe.createUsbIrp();
+        read = camInpipe.createUsbIrp();
         read.setData(recbuf);
         read.setLength(recbuf.length);
         read.setOffset(0);
@@ -113,12 +110,10 @@ public class PTPConnection {
         read.waitUntilComplete(10000); // so we don't block forever when the
                                        // camera poops itself and throw a
                                        // proper exception
-        int readLen =  read.getActualLength();
-        read.complete();
         if (read.isComplete() == false)
             throw new PTPTimeoutException("Camera Reply Timeout");
         PTPPacket response;
-        response = new PTPPacket(Arrays.copyOfRange(recbuf, 0, readLen)); // +40
+        response = new PTPPacket(Arrays.copyOfRange(recbuf, 0, read.getActualLength())); // +40
                                                                                          // this
                                                                                          // is
                                                                                          // a


### PR DESCRIPTION
Reverts acamilo/CHDK-PTP-Java#2

Sorry, but with this update the software fails to work.
Please verify that both the LiveViewDemo and LiveViewApiDemo work with your fix.

E.g. stacktrace is given below:

Feb 03, 2015 2:40:28 PM chdk.ptp.java.camera.AbstractCamera connect
INFO: Connected to camera
Feb 03, 2015 2:40:28 PM chdk.ptp.java.camera.AbstractCamera executeLuaCommand
INFO: Executing: 	"return get_mode();"
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 12
	at chdk.ptp.java.connection.packet.Packet.decodeInt(Packet.java:38)
	at chdk.ptp.java.camera.AbstractCamera.executeLuaCommand(AbstractCamera.java:161)
	at chdk.ptp.java.camera.AbstractCamera.executeLuaQuery(AbstractCamera.java:174)
	at chdk.ptp.java.camera.AbstractCamera.getOperationMode(AbstractCamera.java:492)
	at chdk.ptp.java.camera.AbstractCamera.setOperaionMode(AbstractCamera.java:503)
	at chdk.ptp.java.standalone.LiveViewApiDemo.main(LiveViewApiDemo.java:32)